### PR TITLE
Fix default import for Groq SDK

### DIFF
--- a/app/api/join/services.ts
+++ b/app/api/join/services.ts
@@ -7,7 +7,7 @@ import path from "path";
 import os from "os";
 import { exec } from "child_process";
 import util from "util";
-import { zodResponseFormat } from "openai/helpers/zod.mjs";
+import { zodResponseFormat } from "openai/helpers/zod";
 import { BRollTimestampSchema } from "./schemas";
 const execPromise = util.promisify(exec);
 

--- a/app/api/product-info/route.ts
+++ b/app/api/product-info/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import FirecrawlApp, { ScrapeResponse } from "@mendable/firecrawl-js";
-import { Groq } from "groq-sdk";
+import Groq from "groq-sdk";
 
 import { getSupabase } from "@/supabase/utils";
 


### PR DESCRIPTION
## Summary
- fix import for Groq SDK in product-info route to use the default export
- fix broken zod helper import in join service

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', '@supabase/supabase-js', etc.)*
